### PR TITLE
Don't warn when there are no source files.

### DIFF
--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -75,8 +75,6 @@ gruntTextReplace = {
         typeof src === 'undefined' &&
         typeof replacements === 'undefined') {
       grunt.warn(gruntTextReplace.errorMessages.noTargetsDefined);
-    } else if (src.length === 0) {
-      grunt.warn(gruntTextReplace.errorMessages.noSourceFiles);
     } else if (typeof dest === 'undefined' && overwrite !== true) {
       grunt.warn(gruntTextReplace.errorMessages.noDestination);
     } else if (typeof replacements === 'undefined') {


### PR DESCRIPTION
This is an expected result, e.g., when using wildcards, or something like
https://github.com/tschaub/grunt-newer that only removes unchanged files from
the source list.
