### PR TITLE
Support basic types (Boolean, Number, null) as replacements

### DIFF
--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -138,6 +138,8 @@ gruntTextReplace = {
       return this.expandFunctionReplacement(replacement);
     } else if (typeof replacement === 'string') {
       return this.expandStringReplacement(replacement);
+    } else {
+      return '' + replacement;
     }
   },
 

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -139,7 +139,7 @@ gruntTextReplace = {
     } else if (typeof replacement === 'string') {
       return this.expandStringReplacement(replacement);
     } else {
-      return '' + replacement;
+      return replacement == null ? '' : '' + replacement;
     }
   },
 
@@ -153,7 +153,7 @@ gruntTextReplace = {
       var returnValue = replacement(matchedSubstring, index, fullText,
         regexMatches);
       return (typeof returnValue === 'string') ?
-        gruntTextReplace.processGruntTemplate(returnValue) : returnValue;
+        gruntTextReplace.processGruntTemplate(returnValue) : returnValue == null ? '' : '' + returnValue;
     };
   },
 
@@ -165,7 +165,6 @@ gruntTextReplace = {
     var isProcessTemplateTrue = true;
     if (grunt.task.current.data &&
         grunt.task.current.data.options &&
-        typeof grunt.task.current.data.options.processTemplates !== 'undefined' &&
         grunt.task.current.data.options.processTemplates === false) {
       isProcessTemplateTrue = false;
     }

--- a/test/text-replace-unit-tests.js
+++ b/test/text-replace-unit-tests.js
@@ -46,6 +46,7 @@ exports.textReplace = {
       test.equal(replaceText('Hello \\foo', '\\', ''), 'Hello foo');
       test.equal(replaceText('Foo bar bar', 'bar', 'foo'), 'Foo foo foo');
       test.equal(replaceText('Foo bar bar', 'bar', 'Foo bar'), 'Foo Foo bar Foo bar');
+      test.equal(replaceText('Foo bar baz', ' bar', ''), 'Foo baz');
       test.done();
     },
 
@@ -102,6 +103,8 @@ exports.textReplace = {
       test.equal(replaceText('Hello 0 true 1 false 2345', '0', 1), 'Hello 1 true 1 false 2345');
       test.equal(replaceText('Hello 0 true 1 false 2345', /true|false/g, 0), 'Hello 0 0 1 0 2345');
       test.equal(replaceText('Hello 0 true 1 false 2345', 'Hello', 1e5), '100000 0 true 1 false 2345');
+      test.equal(replaceText('Hello 0 true 1 false 2345', 'Hello', null), ' 0 true 1 false 2345');
+      test.equal(replaceText('Hello 0 true 1 false 2345', 'true', undefined), 'Hello 0  1 false 2345');
       test.done();
     },
 

--- a/test/text-replace-unit-tests.js
+++ b/test/text-replace-unit-tests.js
@@ -95,6 +95,16 @@ exports.textReplace = {
       test.done();
     },
 
+    'Test other arguments types': function (test) {
+      test.equal(replaceText('Hello 0 true 1 false 2345', 'true', false), 'Hello 0 false 1 false 2345');
+      test.equal(replaceText('Hello 0 true 1 false 2345', 'false', true), 'Hello 0 true 1 true 2345');
+      test.equal(replaceText('Hello 0 true 1 false 2345', '1', 22), 'Hello 0 true 22 false 2345');
+      test.equal(replaceText('Hello 0 true 1 false 2345', '0', 1), 'Hello 1 true 1 false 2345');
+      test.equal(replaceText('Hello 0 true 1 false 2345', /true|false/g, 0), 'Hello 0 0 1 0 2345');
+      test.equal(replaceText('Hello 0 true 1 false 2345', 'Hello', 1e5), '100000 0 true 1 false 2345');
+      test.done();
+    },
+
     'Test multiple replacements': function (test) {
       test.equal(replaceTextMultiple('Hello world',
         [{


### PR DESCRIPTION
Sometimes Boolean or Number values can be used as replacements. For example, with the following config

``` js
grunt.initConfig({
  params: {
    flag: true
  },
  replace: {
    main: {
      src: [ '*.txt' ],
      dest: 'build/',
      replacements: [ {
        from: '%flag%',
        to: '<%= params.flag %>'
      } ]
    }
  }
});
```

the Grunt will pass to the plugin the following data:

``` js
{
  ...
  replacements: [ {
    from: '%flag%',
    to: true // WARNING! It is Boolean, not String
  } ]
}
```

because the Grunt replaces strings like '<%= params.flag %>' with requested value as is (look at https://github.com/gruntjs/grunt/blob/v0.4.2/lib/grunt/config.js#L72).
