### PR TITLE
Fix broken grunt.template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ replace: {
 ```
 
 
-[grunt.template]: https://github.com/gruntjs/grunt/wiki/grunt.template
+[grunt.template]: http://gruntjs.com/api/grunt.template
 
 ## Road map
 Some changes I'm considering. Happy to receive suggestions for/against:


### PR DESCRIPTION
grunt api docs are no longer available on the github wiki, they are on gruntjs.com
