### PR TITLE
Expose the current source and destination paths to the replacement function

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Where *to* is a function, the function receives 4 parameters:
 4. **regexMatches**:  an array containing all regex matches, empty if none
 defined or found.
 
+Moreover, if you need access to the path of the current file being processed, or to the replacement destination path, they are available in the function scope as `this.pathToSourceFile` and `this.pathToDestinationFile`.
 
 ```javascript
 // Where the original source file text is:  "Hello world"

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -36,10 +36,10 @@ gruntTextReplace = {
   },
 
   replaceFile: function (settings) {
-    var pathToSourceFile = settings.src;
-    var pathToDestinationFile = this.getPathToDestination(pathToSourceFile, settings.dest);
+    this.pathToSourceFile = settings.src;
+    this.pathToDestinationFile = this.getPathToDestination(this.pathToSourceFile, settings.dest);
     var replacements = settings.replacements;
-    grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
+    grunt.file.copy(this.pathToSourceFile, this.pathToDestinationFile, {
       process: function (text) {
         return gruntTextReplace.replaceTextMultiple(text, replacements);
       }
@@ -135,7 +135,7 @@ gruntTextReplace = {
 
   expandReplacement: function (replacement) {
     if (typeof replacement === 'function') {
-      return this.expandFunctionReplacement(replacement);
+      return this.expandFunctionReplacement(replacement.bind(this));
     } else if (typeof replacement === 'string') {
       return this.expandStringReplacement(replacement);
     } else {


### PR DESCRIPTION
In my use case, I was using the replacement function to manipulate the file text, and I needed to know _which_ file I was editing (full path).

So I exposed the current file path and the current destination path in a way that makes them accessible to the replacement function without having to propagate them all the way down. Let me know if you think this is a suitable solution, or if you'd rather add an additional parameter and propagate it.

I added a note about it in the README.
