### PR TITLE
Pass source file

### DIFF
--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -57,7 +57,7 @@ gruntTextReplace = {
         text: newText,
         from: replacement.from,
         to: replacement.to,
-        srcFile: settings.src
+        src: settings.src
       });
     }, text);
   },
@@ -65,7 +65,7 @@ gruntTextReplace = {
   replaceText: function (settings) {
     var text = settings.text;
     var from = this.convertPatternToRegex(settings.from);
-    var to = this.expandReplacement(settings.to, settings.srcFile);
+    var to = this.expandReplacement(settings.to, settings.src);
     return text.replace(from, to);
   },
 

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -139,9 +139,9 @@ gruntTextReplace = {
     return pattern;
   },
 
-  expandReplacement: function (replacement, srcFile) {
+  expandReplacement: function (replacement, src) {
     if (typeof replacement === 'function') {
-      return this.expandFunctionReplacement(replacement, srcFile);
+      return this.expandFunctionReplacement(replacement, src);
     } else if (typeof replacement === 'string') {
       return this.expandStringReplacement(replacement);
     } else {
@@ -149,15 +149,16 @@ gruntTextReplace = {
     }
   },
 
-  expandFunctionReplacement: function (replacement, srcFile) {
+  expandFunctionReplacement: function (replacement, src) {
     return function () {
-      var matchedSubstring = arguments[0];
-      var index = arguments[arguments.length - 2];
-      var fullText = arguments[arguments.length - 1];
-      var regexMatches = Array.prototype.slice.call(arguments, 1,
-        arguments.length - 2);
-      var returnValue = replacement(matchedSubstring, index, fullText,
-        regexMatches, srcFile);
+      var data = {
+        matchedWord: arguments[0],
+        index: arguments[arguments.length - 2],
+        fullText: arguments[arguments.length - 1],
+        regexMatches: Array.prototype.slice.call(arguments, 1, arguments.length - 2),
+        src: src
+      };
+      var returnValue = replacement(data);
       return (typeof returnValue === 'string') ?
         gruntTextReplace.processGruntTemplate(returnValue) :
         gruntTextReplace.expandNonStringReplacement(returnValue);

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -9,8 +9,7 @@ exports.replace = function (settings) {
 
 exports.replaceText = function (settings) {
   var text = settings.text;
-  var replacements = settings.replacements;
-  return gruntTextReplace.replaceTextMultiple(text, replacements);
+  return gruntTextReplace.replaceTextMultiple(text, settings);
 }
 
 exports.replaceFile = function (settings) {
@@ -46,18 +45,19 @@ gruntTextReplace = {
     if (isReplacementRequired) {
       grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
         process: function (text) {
-          return gruntTextReplace.replaceTextMultiple(text, replacements);
+          return gruntTextReplace.replaceTextMultiple(text, settings);
         }
       });
     }
   },
 
-  replaceTextMultiple: function (text, replacements) {
-    return replacements.reduce(function (newText, replacement) {
+  replaceTextMultiple: function (text, settings) {
+    return settings.replacements.reduce(function (newText, replacement) {
       return gruntTextReplace.replaceText({
         text: newText,
         from: replacement.from,
-        to: replacement.to
+        to: replacement.to,
+        srcFile: settings.src
       });
     }, text);
   },
@@ -65,7 +65,7 @@ gruntTextReplace = {
   replaceText: function (settings) {
     var text = settings.text;
     var from = this.convertPatternToRegex(settings.from);
-    var to = this.expandReplacement(settings.to);
+    var to = this.expandReplacement(settings.to, settings.srcFile);
     return text.replace(from, to);
   },
 
@@ -139,9 +139,9 @@ gruntTextReplace = {
     return pattern;
   },
 
-  expandReplacement: function (replacement) {
+  expandReplacement: function (replacement, srcFile) {
     if (typeof replacement === 'function') {
-      return this.expandFunctionReplacement(replacement);
+      return this.expandFunctionReplacement(replacement, srcFile);
     } else if (typeof replacement === 'string') {
       return this.expandStringReplacement(replacement);
     } else {
@@ -149,7 +149,7 @@ gruntTextReplace = {
     }
   },
 
-  expandFunctionReplacement: function (replacement) {
+  expandFunctionReplacement: function (replacement, srcFile) {
     return function () {
       var matchedSubstring = arguments[0];
       var index = arguments[arguments.length - 2];
@@ -157,7 +157,7 @@ gruntTextReplace = {
       var regexMatches = Array.prototype.slice.call(arguments, 1,
         arguments.length - 2);
       var returnValue = replacement(matchedSubstring, index, fullText,
-        regexMatches);
+        regexMatches, srcFile);
       return (typeof returnValue === 'string') ?
         gruntTextReplace.processGruntTemplate(returnValue) :
         gruntTextReplace.expandNonStringReplacement(returnValue);

--- a/test/text-replace-unit-tests.js
+++ b/test/text-replace-unit-tests.js
@@ -124,6 +124,7 @@ exports.textReplace = {
     setUp: function (done) {
       grunt.file.copy('test/text_files/test.txt', 'test/temp/testA.txt');
       grunt.file.copy('test/text_files/test.txt', 'test/temp/testB.txt');
+      grunt.file.copy('test/text_files/test.txt', 'test/temp/testC.txt');
       sinon.spy(grunt.file, "copy");
       done();
     },
@@ -131,6 +132,7 @@ exports.textReplace = {
     tearDown: function (done) {
       fs.unlinkSync('test/temp/testA.txt');
       fs.unlinkSync('test/temp/testB.txt');
+      fs.unlinkSync('test/temp/testC.txt');
       fs.rmdirSync('test/temp');
       grunt.file.copy.restore();
       done();
@@ -193,6 +195,27 @@ exports.textReplace = {
       test.equal(originalText, 'Hello world');
       test.equal(replacedTextA, 'Hello planet');
       test.equal(replacedTextB, 'Hello planet');
+      test.done();
+    },
+
+    'Test file gets changed according to src file': function (test) {
+      var originalTextA, originalTextC, replacedTextA, replacedTextB;
+      originalTextA = grunt.file.read('test/temp/testA.txt');
+      originalTextC = grunt.file.read('test/temp/testC.txt');
+      replaceFileMultiple(['test/temp/testA.txt', 'test/temp/testC.txt'], 'test/temp/', [{from: 'world', 
+        to: function(matchedWord, index, fullText, regexMatches, srcFile){
+          if(srcFile === 'test/temp/testC.txt'){
+            return 'planet';
+          }
+          else{
+            return matchedWord;
+          }
+        }
+      }]);
+      replacedTextA = grunt.file.read('test/temp/testA.txt');
+      replacedTextC = grunt.file.read('test/temp/testC.txt');
+      test.equal(originalTextA, replacedTextA);
+      test.equal('Hello planet', replacedTextC);
       test.done();
     }
 

--- a/test/text-replace-unit-tests.js
+++ b/test/text-replace-unit-tests.js
@@ -65,31 +65,66 @@ exports.textReplace = {
 
     'Test function replacements': function (test) {
       test.equal(replaceText('Hello world', 'world',
-        function (matchedWord, index, fullText, regexMatches) {
+        function (data) {
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
           return new Array(4).join(matchedWord);
         }), 'Hello worldworldworld');
       test.equal(replaceText('Hello world', 'world',
-        function (matchedWord, index, fullText, regexMatches) {
+        function (data) {
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
           return index;
         }), 'Hello 6');
       test.equal(replaceText('Hello world', 'Hello',
-        function (matchedWord, index, fullText, regexMatches) {
+        function (data) {
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
           return index;
         }), '0 world');
       test.equal(replaceText('Hello world', 'foo',
-        function (matchedWord, index, fullText, regexMatches) {
+        function (data) {
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
           return index;
         }), 'Hello world');
       test.equal(replaceText('Hello world', 'world',
-        function (matchedWord, index, fullText, regexMatches) {
+        function (data) {
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
           return fullText;
         }), 'Hello Hello world');
       test.equal(replaceText('Hello world', /(Hello) (world)/g,
-        function (matchedWord, index, fullText, regexMatches) {
+        function (data) {
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
           return 'Place: ' + regexMatches[1] + ', Greeting: ' + regexMatches[0];
         }), 'Place: world, Greeting: Hello');
       test.equal(replaceText('Hello world', /(Hello) (world)/g,
-        function (matchedWord, index, fullText, regexMatches) {
+        function (data) {
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
           return regexMatches[0] + ' <%= grunt.template.date("20 Nov 2012 11:30:00 GMT", "dd/mm/yy") %>';
         }), 'Hello 20/11/12');
       test.done();
@@ -203,7 +238,13 @@ exports.textReplace = {
       originalTextA = grunt.file.read('test/temp/testA.txt');
       originalTextC = grunt.file.read('test/temp/testC.txt');
       replaceFileMultiple(['test/temp/testA.txt', 'test/temp/testC.txt'], 'test/temp/', [{from: 'world', 
-        to: function(matchedWord, index, fullText, regexMatches, srcFile){
+        to: function(data){
+          var matchedWord = data.matchedWord, 
+              index = data.index, 
+              fullText = data.fullText,
+              regexMatches = data.regexMatches, 
+              srcFile = data.src;
+
           if(srcFile === 'test/temp/testC.txt'){
             return 'planet';
           }


### PR DESCRIPTION
When using a function to handle replacements, expose the source file, and consolidate arguments into a "data" variable, as requested in issues: https://github.com/yoniholmes/grunt-text-replace/issues/2

grunt test passes
