### PR TITLE
Adds an expand option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ replace: {
 }
 ```
 
+Here's another example using the expand option
+
+```javascript
+replace: {
+  another_example: {
+    options: {
+      expand: true
+    },
+    src: ['build/**/*.html'],
+    dest: 'dist/',
+    replacements: [{
+      from: /[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4}/g,
+      to: "<%= grunt.template.today('dd/mm/yyyy') %>"
+    }]
+  }
+}
+```
+
 
 
 ## API reference
@@ -75,6 +93,9 @@ name anything you like.
 
 [multitask]: https://github.com/gruntjs/grunt/wiki/Configuring-tasks#task-configuration-and-targets
 
+### expand
+
+*expand* will create the destination path in full
 
 ### src
 

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -2,7 +2,6 @@ var grunt = require('grunt');
 var path = require('path');
 var gruntTextReplace = {};
 
-
 exports.replace = function (settings) {
   gruntTextReplace.replace(settings);
 }
@@ -21,14 +20,16 @@ exports.replaceFileMultiple = function (settings) {
   return gruntTextReplace.replaceFileMultiple(settings)
 }
 
-
-
 gruntTextReplace = {
   replaceFileMultiple: function (settings) {
+
     var sourceFiles = grunt.file.expand(settings.src);
+
     sourceFiles.forEach(function (pathToSource) {
       gruntTextReplace.replaceFile({
+        options: settings.options,
         src: pathToSource,
+        origSrc: settings.origSrc,
         dest: settings.dest,
         replacements: settings.replacements
       });
@@ -36,20 +37,16 @@ gruntTextReplace = {
   },
 
   replaceFile: function (settings) {
+
     var pathToSourceFile = settings.src;
-    var pathToDestinationFile = this.getPathToDestination(pathToSourceFile, settings.dest);
+    var pathToDestinationFile = this.getPathToDestination(pathToSourceFile, settings.dest, settings);
     var replacements = settings.replacements;
-    var isThereAGenuineReplacement = replacements.reduce(function (previous, current) { 
-      return previous || (current.from !== current.to) 
-    }, false);
-    var isReplacementRequired = (pathToSourceFile !== pathToDestinationFile) || isThereAGenuineReplacement
-    if (isReplacementRequired) {
-      grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
-        process: function (text) {
-          return gruntTextReplace.replaceTextMultiple(text, replacements);
-        }
-      });
-    }
+    console.log(pathToDestinationFile);
+    grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
+      process: function (text) {
+        return gruntTextReplace.replaceTextMultiple(text, replacements);
+      }
+    });
   },
 
   replaceTextMultiple: function (text, replacements) {
@@ -70,12 +67,13 @@ gruntTextReplace = {
   },
 
   replace: function (settings) {
-    var src = grunt.file.expand(settings.src || []);
     var dest = settings.dest;
     var overwrite = settings.overwrite;
     var replacements = settings.replacements;
     var isDestinationDirectory = (/\/$/).test(dest);
+    var src = isDestinationDirectory ? grunt.file.expand(settings.src || []) : settings.src;
     var initialWarnCount = grunt.fail.warncount;
+    var options = settings.options;
 
     if (typeof dest === 'undefined' &&
         typeof src === 'undefined' &&
@@ -90,8 +88,11 @@ gruntTextReplace = {
     } else if ((isDestinationDirectory === false && src.length > 1) && overwrite !== true) {
       grunt.warn(gruntTextReplace.errorMessages.multipleSourceSingleDestination);
     } else if (grunt.fail.warncount - initialWarnCount === 0) {
+
       gruntTextReplace.replaceFileMultiple({
+        options: options,
         src: src,
+        origSrc: settings.src,
         dest: dest,
         replacements: replacements
       });
@@ -115,15 +116,30 @@ gruntTextReplace = {
       "file, make sure there is only one source file"
   },
 
-  getPathToDestination: function (pathToSource, pathToDestinationFile) {
+  getPathToDestination: function (pathToSource, pathToDestinationFile, settings) {
     var isDestinationDirectory = (/\/$/).test(pathToDestinationFile);
     var fileName = path.basename(pathToSource);
     var newPathToDestination;
-    if (typeof pathToDestinationFile === 'undefined') {
+    var srcPath, omitDirs = '';
+
+    if (typeof pathToDestinationFile === 'undefined'){
       newPathToDestination = pathToSource;
+    } else if(settings.options && settings.options.hasOwnProperty('expand') && settings.options.expand === true){
+
+      settings.origSrc.forEach(function(src){
+        srcPath = src.substr(0, pathToSource.lastIndexOf('/'));
+        srcPath.split('/').forEach(function(dir){
+          if(!/\*/g.test(dir)){
+            omitDirs += dir + '/';
+          }
+        });
+      });
+      return pathToSource.replace(omitDirs, pathToDestinationFile.toString());
+
     } else {
       newPathToDestination = pathToDestinationFile + (isDestinationDirectory ? fileName : '');
     }
+
     return newPathToDestination;
   },
 

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -2,7 +2,6 @@ var grunt = require('grunt');
 var path = require('path');
 var gruntTextReplace = {};
 
-
 exports.replace = function (settings) {
   gruntTextReplace.replace(settings);
 }
@@ -23,7 +22,9 @@ exports.replaceFileMultiple = function (settings) {
 
 gruntTextReplace = {
   replaceFileMultiple: function (settings) {
+
     var sourceFiles = grunt.file.expand(settings.src);
+
     sourceFiles.forEach(function (pathToSource) {
       gruntTextReplace.replaceFile({
         options: settings.options,
@@ -36,10 +37,11 @@ gruntTextReplace = {
   },
 
   replaceFile: function (settings) {
+
     var pathToSourceFile = settings.src;
     var pathToDestinationFile = this.getPathToDestination(pathToSourceFile, settings.dest, settings);
     var replacements = settings.replacements;
-
+    console.log(pathToDestinationFile);
     grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
       process: function (text) {
         return gruntTextReplace.replaceTextMultiple(text, replacements);
@@ -86,6 +88,7 @@ gruntTextReplace = {
     } else if ((isDestinationDirectory === false && src.length > 1) && overwrite !== true) {
       grunt.warn(gruntTextReplace.errorMessages.multipleSourceSingleDestination);
     } else if (grunt.fail.warncount - initialWarnCount === 0) {
+
       gruntTextReplace.replaceFileMultiple({
         options: options,
         src: src,

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -21,14 +21,14 @@ exports.replaceFileMultiple = function (settings) {
   return gruntTextReplace.replaceFileMultiple(settings)
 }
 
-
-
 gruntTextReplace = {
   replaceFileMultiple: function (settings) {
     var sourceFiles = grunt.file.expand(settings.src);
     sourceFiles.forEach(function (pathToSource) {
       gruntTextReplace.replaceFile({
+        options: settings.options,
         src: pathToSource,
+        origSrc: settings.origSrc,
         dest: settings.dest,
         replacements: settings.replacements
       });
@@ -37,19 +37,14 @@ gruntTextReplace = {
 
   replaceFile: function (settings) {
     var pathToSourceFile = settings.src;
-    var pathToDestinationFile = this.getPathToDestination(pathToSourceFile, settings.dest);
+    var pathToDestinationFile = this.getPathToDestination(pathToSourceFile, settings.dest, settings);
     var replacements = settings.replacements;
-    var isThereAGenuineReplacement = replacements.reduce(function (previous, current) { 
-      return previous || (current.from !== current.to) 
-    }, false);
-    var isReplacementRequired = (pathToSourceFile !== pathToDestinationFile) || isThereAGenuineReplacement
-    if (isReplacementRequired) {
-      grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
-        process: function (text) {
-          return gruntTextReplace.replaceTextMultiple(text, replacements);
-        }
-      });
-    }
+
+    grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
+      process: function (text) {
+        return gruntTextReplace.replaceTextMultiple(text, replacements);
+      }
+    });
   },
 
   replaceTextMultiple: function (text, replacements) {
@@ -70,12 +65,13 @@ gruntTextReplace = {
   },
 
   replace: function (settings) {
-    var src = grunt.file.expand(settings.src || []);
     var dest = settings.dest;
     var overwrite = settings.overwrite;
     var replacements = settings.replacements;
     var isDestinationDirectory = (/\/$/).test(dest);
+    var src = isDestinationDirectory ? grunt.file.expand(settings.src || []) : settings.src;
     var initialWarnCount = grunt.fail.warncount;
+    var options = settings.options;
 
     if (typeof dest === 'undefined' &&
         typeof src === 'undefined' &&
@@ -91,7 +87,9 @@ gruntTextReplace = {
       grunt.warn(gruntTextReplace.errorMessages.multipleSourceSingleDestination);
     } else if (grunt.fail.warncount - initialWarnCount === 0) {
       gruntTextReplace.replaceFileMultiple({
+        options: options,
         src: src,
+        origSrc: settings.src,
         dest: dest,
         replacements: replacements
       });
@@ -115,15 +113,30 @@ gruntTextReplace = {
       "file, make sure there is only one source file"
   },
 
-  getPathToDestination: function (pathToSource, pathToDestinationFile) {
+  getPathToDestination: function (pathToSource, pathToDestinationFile, settings) {
     var isDestinationDirectory = (/\/$/).test(pathToDestinationFile);
     var fileName = path.basename(pathToSource);
     var newPathToDestination;
-    if (typeof pathToDestinationFile === 'undefined') {
+    var srcPath, omitDirs = '';
+
+    if (typeof pathToDestinationFile === 'undefined'){
       newPathToDestination = pathToSource;
+    } else if(settings.options && settings.options.hasOwnProperty('expand') && settings.options.expand === true){
+
+      settings.origSrc.forEach(function(src){
+        srcPath = src.substr(0, pathToSource.lastIndexOf('/'));
+        srcPath.split('/').forEach(function(dir){
+          if(!/\*/g.test(dir)){
+            omitDirs += dir + '/';
+          }
+        });
+      });
+      return pathToSource.replace(omitDirs, pathToDestinationFile.toString());
+
     } else {
       newPathToDestination = pathToDestinationFile + (isDestinationDirectory ? fileName : '');
     }
+
     return newPathToDestination;
   },
 

--- a/tasks/text-replace.js
+++ b/tasks/text-replace.js
@@ -10,8 +10,6 @@ var gruntTextReplace = require('../lib/grunt-text-replace');
 
 module.exports = function(grunt) {
 
-
-
   // Please see the grunt documentation for more information regarding task
   // creation: https://github.com/gruntjs/grunt/blob/devel/docs/toc.md
 
@@ -23,7 +21,8 @@ module.exports = function(grunt) {
         src: this.data.src,
         dest: this.data.dest,
         overwrite: this.data.overwrite,
-        replacements: this.data.replacements
+        replacements: this.data.replacements,
+        options: this.data.options
       });
     });
 };


### PR DESCRIPTION
This will allow wildcard src paths i.e `**/*` to be fully created in the destination path. So if I have a wildcard src match with a path: `src/somedir/index.html` and a dest as `dist/` the expand option will ensure the destination path is `dist/somedir/index.html` and not `dist/index.html` which would overwrite any `dist/index.html` that there may have been.
