### PR TITLE
Pass processing file path to the replacement function and support all of Grunt configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,15 @@ grunt-text-replace will throw an error. You can only use one or the other.
 
 
 #### function
-Where *to* is a function, the function receives 4 parameters:
+Where *to* is a function, the function receives 6 parameters:
 
 1. **matchedWord**:  the matched word
 2. **index**:  an integer representing point where word was found in a text
 3. **fullText**:  the full original text
 4. **regexMatches**:  an array containing all regex matches, empty if none
-defined or found.
-
+defined or found
+5. **sourceFilePath**: the processing source file path
+6. **destinationFilePath**: the processing destination file path.
 
 ```javascript
 // Where the original source file text is:  "Hello world"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ a single file.
 *overwrite* should be used for in-place replacement, that is when all you need
 to do is overwrite existing files.
 To use it, omit *dest*, otherwise
-grunt-text-replace will throw an error. You can only use one or the other. 
+grunt-text-replace will throw an error. You can only use one or the other.
 
 
 ### replacements
@@ -203,6 +203,13 @@ replace: {
 
 
 [grunt.template]: http://gruntjs.com/api/grunt.template
+
+
+### files formats
+Files formats are defined by grunt, see [Grunt Configuration]
+
+[Grunt Configuration]: http://gruntjs.com/configuring-tasks
+
 
 ## Road map
 Some changes I'm considering. Happy to receive suggestions for/against:

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -46,18 +46,20 @@ gruntTextReplace = {
     if (isReplacementRequired) {
       grunt.file.copy(pathToSourceFile, pathToDestinationFile, {
         process: function (text) {
-          return gruntTextReplace.replaceTextMultiple(text, replacements);
+          return gruntTextReplace.replaceTextMultiple(text, replacements,pathToSourceFile, pathToDestinationFile);
         }
       });
     }
   },
 
-  replaceTextMultiple: function (text, replacements) {
+  replaceTextMultiple: function (text, replacements,pathToSourceFile, pathToDestinationFile) {
     return replacements.reduce(function (newText, replacement) {
       return gruntTextReplace.replaceText({
         text: newText,
         from: replacement.from,
-        to: replacement.to
+        to: replacement.to,
+        pathToSourceFile: pathToSourceFile,
+        pathToDestinationFile: pathToDestinationFile
       });
     }, text);
   },
@@ -65,7 +67,7 @@ gruntTextReplace = {
   replaceText: function (settings) {
     var text = settings.text;
     var from = this.convertPatternToRegex(settings.from);
-    var to = this.expandReplacement(settings.to);
+    var to = this.expandReplacement(settings.to, settings.pathToSourceFile, settings.pathToDestinationFile);
     return text.replace(from, to);
   },
 
@@ -139,9 +141,9 @@ gruntTextReplace = {
     return pattern;
   },
 
-  expandReplacement: function (replacement) {
+  expandReplacement: function (replacement,pathToSourceFile, pathToDestinationFile) {
     if (typeof replacement === 'function') {
-      return this.expandFunctionReplacement(replacement);
+      return this.expandFunctionReplacement(replacement,pathToSourceFile, pathToDestinationFile);
     } else if (typeof replacement === 'string') {
       return this.expandStringReplacement(replacement);
     } else {
@@ -149,7 +151,7 @@ gruntTextReplace = {
     }
   },
 
-  expandFunctionReplacement: function (replacement) {
+  expandFunctionReplacement: function (replacement,pathToSourceFile, pathToDestinationFile) {
     return function () {
       var matchedSubstring = arguments[0];
       var index = arguments[arguments.length - 2];
@@ -157,7 +159,7 @@ gruntTextReplace = {
       var regexMatches = Array.prototype.slice.call(arguments, 1,
         arguments.length - 2);
       var returnValue = replacement(matchedSubstring, index, fullText,
-        regexMatches);
+        regexMatches,pathToSourceFile, pathToDestinationFile);
       return (typeof returnValue === 'string') ?
         gruntTextReplace.processGruntTemplate(returnValue) :
         gruntTextReplace.expandNonStringReplacement(returnValue);

--- a/tasks/text-replace.js
+++ b/tasks/text-replace.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
     'text in files using strings, regexs or functions.',
     function () {
       var data = this.data;
-      var srcFiles = this.files.forEach(function(elem){
+      this.files.forEach(function(elem){
         gruntTextReplace.replace({
           src: elem.src,
           dest: elem.dest,

--- a/tasks/text-replace.js
+++ b/tasks/text-replace.js
@@ -19,11 +19,14 @@ module.exports = function(grunt) {
     'General purpose text replacement for grunt. Allows you to replace ' +
     'text in files using strings, regexs or functions.',
     function () {
-      gruntTextReplace.replace({
-        src: this.data.src,
-        dest: this.data.dest,
-        overwrite: this.data.overwrite,
-        replacements: this.data.replacements
+      var data = this.data;
+      var srcFiles = this.files.forEach(function(elem){
+        gruntTextReplace.replace({
+          src: elem.src,
+          dest: elem.dest,
+          overwrite: data.overwrite,
+          replacements: data.replacements
+        });
       });
     });
 };


### PR DESCRIPTION
Add two parameters to "to" if "to" is a function. The fifth parameter of "to" is the path of source file, and the sixth is the path of destination file. You can do extra work to the source and destination files in the function.
