### PR TITLE
Added support for destination to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ It supports [minimatch][minimatch] paths.
 
 - file: `'path/output.txt'`
 - directory: `'path/'`
+- function: ```function (input) {
+  return input;
+}```
 
 grunt-text-replace will throw an error if multiple source files are mapped to
 a single file.

--- a/lib/grunt-text-replace.js
+++ b/lib/grunt-text-replace.js
@@ -74,7 +74,7 @@ gruntTextReplace = {
     var dest = settings.dest;
     var overwrite = settings.overwrite;
     var replacements = settings.replacements;
-    var isDestinationDirectory = (/\/$/).test(dest);
+    var isDestinationDirectory = (/\/$/).test(dest) || typeof dest === 'function';
     var initialWarnCount = grunt.fail.warncount;
 
     if (typeof dest === 'undefined' &&
@@ -116,6 +116,10 @@ gruntTextReplace = {
   },
 
   getPathToDestination: function (pathToSource, pathToDestinationFile) {
+    if (typeof pathToDestinationFile === 'function') {
+      pathToDestinationFile = pathToDestinationFile(pathToSource);
+    }
+
     var isDestinationDirectory = (/\/$/).test(pathToDestinationFile);
     var fileName = path.basename(pathToSource);
     var newPathToDestination;

--- a/test/text-replace-unit-tests.js
+++ b/test/text-replace-unit-tests.js
@@ -194,6 +194,20 @@ exports.textReplace = {
       test.equal(replacedTextA, 'Hello planet');
       test.equal(replacedTextB, 'Hello planet');
       test.done();
+    },
+
+    'Test function as destination': function (test) {
+      var originalText, replacedTextA, replacedTextB;
+      originalText = grunt.file.read('test/temp/testA.txt');
+      replaceFileMultiple(['test/temp/test*.txt'], function (input) {
+        return input + '.foo';
+      }, [{from: 'world', to: 'planet'}]);
+      replacedTextA = grunt.file.read('test/temp/testA.txt.foo');
+      replacedTextB = grunt.file.read('test/temp/testB.txt.foo');
+      test.equal(originalText, 'Hello world');
+      test.equal(replacedTextA, 'Hello planet');
+      test.equal(replacedTextB, 'Hello planet');
+      test.done();
     }
 
   }


### PR DESCRIPTION
So I needed the ability to also change the filename of the replaced files, so I added the ability to specify destination as a function, for example:

``` javascript
replace: {
  all: {
    src: ['foo.json', 'bar/*.json'],
    dest: function (input) {
      return input + '.j2';
    },
    replacements: [{
      from: 'foo',
      to: 'bar'
    }]
  }
}
```

Hope that's cool :)
